### PR TITLE
Entferne Kleinkram in Sprint-Übersicht

### DIFF
--- a/jobs/_jira__board_status.rb
+++ b/jobs/_jira__board_status.rb
@@ -35,8 +35,7 @@ class BoardStatus
       if is_state?(issue, state_id) && !is_subtask?(issue)
         state[:tickets] = state[:tickets] + 1
         state[:story_points] = state[:story_points] + story_points(issue)
-        state[:task_force] = state[:task_force] + (is_taskforce?(issue) ? 1 : 0)
-        state[:kleikram] = state[:kleinkram] + (is_kleinkram?(issue) ? 1 : 0)
+        state[:task_force] = state[:task_force] + (is_taskforce?(issue) ? 1 : 0)  
       end
     end
 
@@ -55,10 +54,6 @@ class BoardStatus
     !issue['fields'][@sprint.story_points_field_name].nil? ? issue['fields'][@sprint.story_points_field_name] : 0
   end
 
-  def is_kleinkram?(issue)
-    issue['fields']['labels'].include?('Kleinkram')
-  end
-
   def is_taskforce?(issue)
     issue['fields']['labels'].include?('TaskForce')
   end
@@ -69,7 +64,6 @@ class BoardStatus
       sum[:tickets] = sum[:tickets] + state[:tickets]
       sum[:story_points] = sum[:story_points] + state[:story_points]
       sum[:task_force] = sum[:task_force] + state[:task_force]
-      sum[:kleinkram] = sum[:kleinkram] + state[:kleinkram]
     end
     sum
   end
@@ -78,8 +72,7 @@ class BoardStatus
     {
       tickets: 0,
       story_points: 0,
-      task_force: 0,
-      kleinkram: 0
+      task_force: 0
     }
   end
 

--- a/jobs/jira_scheduler.rb
+++ b/jobs/jira_scheduler.rb
@@ -55,31 +55,27 @@ SCHEDULER.every '30s', first_in: 0 do
       sprintTickets: sprint_info[:tickets],
       sprintSP: sprint_info[:story_points],
       sprintTaskForce: sprint_info[:task_force],
-      sprintKleinkram: sprint_info[:kleinkram],
 
       backlogTickets: backlog[:tickets],
       backlogSP: backlog[:story_points],
       backlogTaskForce: backlog[:task_force],
-      backlogKleinkram: backlog[:kleinkram],
 
       inProgressTickets: in_progress[:tickets],
       inProgressSP: in_progress[:story_points],
       inProgressTaskForce: in_progress[:task_force],
-      inProgressKleinkram: in_progress[:kleinkram],
 
       inReviewTickets: in_review[:tickets],
       inReviewSP: in_review[:story_points],
       inReviewTaskForce: in_review[:task_force],
-      inReviewKleinkram: in_review[:kleinkram],
 
       inTestTickets: in_test[:tickets],
       inTestSP: in_test[:story_points],
       inTestTaskForce: in_test[:task_force],
-      inTestKleinkram: in_test[:kleinkram],
 
       doneTickets: done[:tickets],
       doneSP: done[:story_points],
       doneTaskForce: done[:task_force],
-      doneKleinkram: done[:kleinkram]
+
+      updated_at: DateTime.now.strftime('%H:%M Uhr, %d.%m.%Y')
   })
 end

--- a/widgets/jira_sprint_board_status/jira_sprint_board_status.html
+++ b/widgets/jira_sprint_board_status/jira_sprint_board_status.html
@@ -1,5 +1,11 @@
 <div class="sprint-status">
         <div class="sprint-status-column">
+            <div class="sprint-state-icon">
+                <i style="visibility: hidden;" class="fas fa-running"></i>
+            </div>
+            <div class="sprint-state-label">
+                    &nbsp;
+                </div>
             <div class="sprint-state-explanation">
                 Tickets
             </div>
@@ -9,13 +15,13 @@
             <div class="sprint-state-explanation">
                 TaskForce
             </div>
-            <div class="sprint-state-explanation">
-                Kleinkram
-            </div>
         </div>
     <div class="sprint-status-column">
+        <div class="sprint-state-icon">
+            <i class="fas fa-running"></i>
+        </div>
         <div class="sprint-state-label">
-            Aktueller Sprint
+            Sprint
         </div>
         <div class="sprint-state-value" data-bind="sprintTickets">
             …
@@ -25,9 +31,6 @@
         </div>
         <div class="sprint-state-value" data-bind="sprintTaskForce">
             …
-        </div>
-        <div class="sprint-state-value" data-bind="sprintKleinkram">
-                …
         </div>
     </div>
     
@@ -45,11 +48,8 @@
             …
         </div>
         <div class="sprint-state-value" data-bind="backlogTaskForce">
-                …
-            </div>
-            <div class="sprint-state-value" data-bind="backlogKleinkram">
-                    …
-            </div>
+            …
+        </div>
     </div>
     <div class="sprint-status-column">
         <div class="sprint-state-icon">
@@ -67,9 +67,6 @@
         <div class="sprint-state-value" data-bind="inProgressTaskForce">
             …
         </div>
-        <div class="sprint-state-value" data-bind="inProgressKleinkram">
-                …
-        </div>
     </div>
     <div class="sprint-status-column">
         <div class="sprint-state-icon">
@@ -85,9 +82,6 @@
             …
         </div>
         <div class="sprint-state-value" data-bind="inReviewTaskForce">
-            …
-        </div>
-        <div class="sprint-state-value" data-bind="inReviewKleinkram">
             …
         </div>
     </div>
@@ -107,9 +101,6 @@
         <div class="sprint-state-value" data-bind="inTestTaskForce">
             …
         </div>
-        <div class="sprint-state-value" data-bind="inTestKleinkram">
-                …
-        </div>
     </div>
     <div class="sprint-status-column">
         <div class="sprint-state-icon">
@@ -127,9 +118,7 @@
         <div class="sprint-state-value" data-bind="doneTaskForce">
             …
         </div>
-        <div class="sprint-state-value" data-bind="doneKleinkram">
-            …
-        </div>
     </div>
 </div>
+<div data-bind="updated_at" class="updated_at">...</div>
 

--- a/widgets/jira_sprint_board_status/jira_sprint_board_status.scss
+++ b/widgets/jira_sprint_board_status/jira_sprint_board_status.scss
@@ -25,7 +25,7 @@ $column-width: 100% / length($states);
       display: flex;
       align-items: end;
       flex-flow: column;
-      justify-content: flex-end;
+      justify-content: center;
 
       &:nth-child(odd) {
         background: rgba(255,255,255,0.05);
@@ -74,5 +74,19 @@ $column-width: 100% / length($states);
         height: 2rem;
       }
     }
+  }
+}
+
+.updated_at {
+  position: absolute;
+  bottom: 1rem;
+  left: 0;
+  right: 0;
+  font-weight: unset;
+  font-size: 1rem;
+  color: rgba(255, 255, 255, .5);
+
+  &::before {
+      content: "Stand: ";
   }
 }


### PR DESCRIPTION
Entferne die nicht mehr benötigte Kleinkram-Zeile.

Dafür musste in der View ein bisschen mit unsichtbaren Platzhaltern getrickst werden.

Zusätzlich ist der Stand der letzten Aktualisierung mit angegeben.