### PR TITLE
Fix: NRE bei fehlendem Assignee Avatar

### DIFF
--- a/jobs/gitlab_ci_open_mergerequests.rb
+++ b/jobs/gitlab_ci_open_mergerequests.rb
@@ -32,11 +32,16 @@ class GitlabOpenMergeRequests
 
   def redirect_resources(merge_requests_list)
     if @config['gitlab']['redirect_resources'] == true
+      merge_requests_list.each do |request|
+        if valid_assignee?(request)
+          request['assignee']['avatar_url'].gsub!(@config['gitlab']['redirect']['from'], @config['gitlab']['redirect']['to'])
+        end
+      end
+    end
+  end
 
-    merge_requests_list.each do |request|
-        request['assignee']['avatar_url'].gsub!(@config['gitlab']['redirect']['from'], @config['gitlab']['redirect']['to']) if (request.key?('assignee') && !request['assignee'].nil? && request['assignee'].key?('avatar_url'))
-    end
-    end
+  def valid_assignee?(request)
+    request.key?('assignee') && !request['assignee'].nil? && request['assignee'].key?('avatar_url') && request['assignee']['avatar_url'].nil?
   end
 end
 

--- a/widgets/gitlab_ci_open_mergerequests/gitlab_ci_open_mergerequests.html
+++ b/widgets/gitlab_ci_open_mergerequests/gitlab_ci_open_mergerequests.html
@@ -2,21 +2,31 @@
   <div class="widget_title">Offene Merge Requests</div>
   <ul class="merge-request-list">
     <li data-foreach-item="mergerequests" class="merge-request">
-        <div class="merge-request-user" data-showif="item.assignee">
-            <img data-bind-src="item.assignee.avatar_url" class="merge-request-image" />
-        </div>
 
-        <div class="merge-request-user" data-hideif="item.assignee">
-            <div class="merge-request-user-empty">
-                <i class="fas fa-user-slash"></i>
+        <div class="merge-request-user-info">
+            <div class="merge-request-user" data-showif="item.assignee">
+                <img data-bind-src="item.assignee.avatar_url" class="merge-request-user-avatar" />
+            </div>
+    
+            <div class="merge-request-user" data-hideif="item.assignee">
+                <div class="merge-request-user-empty">
+                    <i class="fas fa-user-slash"></i>
+                </div>
             </div>
         </div>
-
+        <div class="merge-request-base-info">
+            <div data-bind="item.iid" class="merge-request-id">...</div>
+            <div class="merge-request-project-name">PROSOZ Bau Rich Client</div>
+        </div>
         <div class="merge-request-data">
             <div class="merge-request-meta">
                 <div data-bind="item.title" class="merge-request-summary">...</div>
             </div>
         </div>
+
+        
+
+        
     </li>
   </ul>
   <div data-showif="hasNoIssues">

--- a/widgets/gitlab_ci_open_mergerequests/gitlab_ci_open_mergerequests.scss
+++ b/widgets/gitlab_ci_open_mergerequests/gitlab_ci_open_mergerequests.scss
@@ -2,7 +2,9 @@ $background-color: rgba(167, 212, 236, 0.4);
 $updated-at-color: rgba(255, 255, 255, .5);;
 
 .widget-gitlab-ci-open-mergerequests {
-    .open-merge-requests {        
+    .open-merge-requests {     
+        padding-left: .3rem;
+        padding-right: .3rem;  
         display: flex;
         align-items: center;
         flex-direction: column;
@@ -11,35 +13,77 @@ $updated-at-color: rgba(255, 255, 255, .5);;
     
         .widget_title {
             margin: 1rem;
-            }
+        }
 
         .merge-request {
+            padding: .6rem;
+            margin-top: .2rem;
+            margin-bottom: .2rem;
             background: rgba($color: white, $alpha: 0.2);
-            margin-left: .4rem;
-            margin-right: .4rem;
-            display: flex;
-            align-items: flex-start;
-            flex-direction: row;
-            justify-items: center;
+            display: grid;
+            grid-template-columns: 3rem auto;
+            grid-template-rows: auto auto;
+            gap: .2rem;
+
+            .merge-request-user-info {
+                grid-column: 1;
+                grid-row-start: 1;
+                grid-row-end: span 2;
+                display: flex;
+                align-items: center;
+            }
+
+            .merge-request-base-info {
+                grid-column: 2;
+                grid-row: 1;
+                padding-left: .6rem;
+                padding-right: .6rem;
+                font-size: .8rem;
+                font-family: 'Open Sans';
+                font-weight: 300;
+                display: flex;
+                flex-direction: row;
+                align-items: flex-start;
+
+                .merge-request-id {
+                    &::before {
+                        content: "#";
+                    }
+                }
+        
+                .merge-request-project-name {
+                    &::before {
+                        padding: .2rem;
+                        content: "|";
+                    }
+                }
+            }
     
             .merge-request-user {
-                margin-left: .5rem;
-                padding-top: .5rem;
                 flex-shrink: 0;
                 width: 3rem;
-                height: 100%;
+                height: 3rem;
+
+                .merge-request-user-avatar {
+                    border-radius: 50%;
+                }
+
                 .merge-request-user-empty{
                     font-size: 2.5rem;
                 }
             }
     
             .merge-request-data {
-                padding: .6rem;
-                flex-shrink: 1;
+                padding-left: .6rem;
+                padding-right: .6rem;
+                grid-column: 2;
+                grid-row: 2;
+                display: flex;
+                flex-direction: column;
+                align-items: flex-start;
     
                 .merge-request-meta {
-                    overflow: hidden;
-                    height: 3rem;
+                    height: auto;
                     display: flex;
                     flex-direction: row;
                     align-items: flex-start;

--- a/widgets/gitlab_ci_open_mergerequests/gitlab_ci_open_mergerequests.scss
+++ b/widgets/gitlab_ci_open_mergerequests/gitlab_ci_open_mergerequests.scss
@@ -60,12 +60,11 @@ $updated-at-color: rgba(255, 255, 255, .5);;
             }
     
             .merge-request-user {
-                flex-shrink: 0;
-                width: 3rem;
-                height: 3rem;
 
                 .merge-request-user-avatar {
                     border-radius: 50%;
+                    width: 3rem;
+                    height: 3rem;
                 }
 
                 .merge-request-user-empty{


### PR DESCRIPTION
Es wurde optimistisch davon ausgegangen, dass ein Assignee immer eine gültige `avatar_url`beinhaltet.

Dies wird nun abgefangen und beim redirecten der URLs berücksichtigt.