### PR TITLE
Beschränke Auswahl der Merge Requests

### DIFF
--- a/jobs/gitlab_ci_open_mergerequests.rb
+++ b/jobs/gitlab_ci_open_mergerequests.rb
@@ -7,7 +7,7 @@ class GitlabOpenMergeRequests
   def initialize(config, project_id)
     @config = config
     @project_id = project_id
-    @mergerequest_endpoint = "#{@config['gitlab']['api_endpoint']}/projects/#{@project_id}/merge_requests?state=opened"
+    @mergerequest_endpoint = "#{@config['gitlab']['api_endpoint']}/projects/#{@project_id}/merge_requests?state=opened&wip=no"
   end
 
   def retrieve_open_mergerequests


### PR DESCRIPTION
Nur mal ein Vorschlag meinerseits:

Ignoriere Merge Requests, die sich aktuell in Bearbeitung befinden.