### PR TITLE
Fix broken asset pipeline calls

### DIFF
--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -1,11 +1,9 @@
-/*
-  //=require_directory .
-  //=require ./fontawesome/fontawesome.scss
-  //= require ./fontawesome/solid.scss
-  //= require ./fontawesome/regular.scss
-  //= require open-sans-font.scss
-  //=require_tree ../../widgets
-*/
+//= require_directory .
+//= require ./fontawesome/fontawesome
+//= require ./fontawesome/solid
+//= require ./fontawesome/regular
+//= require open-sans-font
+//= require_tree ../../widgets
 // ----------------------------------------------------------------------------
 // Sass declarations
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Inside `application.scss` we use an broken way to require the used sass/css files.

This is going to fix this.